### PR TITLE
WindFree availability, audio volume number, and Samsung OCF display switch

### DIFF
--- a/custom_components/smartthings/climate.py
+++ b/custom_components/smartthings/climate.py
@@ -366,9 +366,31 @@ class SmartThingsAirConditioner(SmartThingsEntity, ClimateEntity):
         )
         if self.supports_capability(Capability.FAN_OSCILLATION_MODE):
             features |= ClimateEntityFeature.SWING_MODE
-        if (self._attr_preset_modes is not None) and len(self._attr_preset_modes) > 0:
+        if self._supports_windfree():
             features |= ClimateEntityFeature.PRESET_MODE
         return features
+
+    def _supports_windfree(self) -> bool:
+        """Return whether the device exposes WindFree as an optional AC mode."""
+        if not self.supports_capability(Capability.CUSTOM_AIR_CONDITIONER_OPTIONAL_MODE):
+            return False
+
+        supported_modes = self.get_attribute_value(
+            Capability.CUSTOM_AIR_CONDITIONER_OPTIONAL_MODE,
+            Attribute.SUPPORTED_AC_OPTIONAL_MODE,
+        )
+        return bool(supported_modes) and WINDFREE in supported_modes
+
+    def _windfree_available(self) -> bool:
+        """Return whether WindFree should currently be selectable."""
+        if not self._supports_windfree():
+            return False
+
+        current_mode = self.get_attribute_value(
+            Capability.AIR_CONDITIONER_MODE,
+            Attribute.AIR_CONDITIONER_MODE,
+        )
+        return current_mode not in {"auto", "heat"}
 
     async def async_set_fan_mode(self, fan_mode: str) -> None:
         """Set new target fan mode."""
@@ -545,14 +567,23 @@ class SmartThingsAirConditioner(SmartThingsEntity, ClimateEntity):
 
     def _determine_preset_modes(self) -> list[str] | None:
         """Return a list of available preset modes."""
-        if self.supports_capability(Capability.CUSTOM_AIR_CONDITIONER_OPTIONAL_MODE):
-            supported_modes = self.get_attribute_value(
-                Capability.CUSTOM_AIR_CONDITIONER_OPTIONAL_MODE,
-                Attribute.SUPPORTED_AC_OPTIONAL_MODE,
-            )
-            if supported_modes and WINDFREE in supported_modes:
-                return [WINDFREE]
-        return None
+        if self._windfree_available():
+            return [WINDFREE]
+        return []
+
+    @property
+    def preset_mode(self) -> str | None:
+        """Return the current optional AC mode if it is a supported HA preset."""
+        preset_mode = self.get_attribute_value(
+            Capability.CUSTOM_AIR_CONDITIONER_OPTIONAL_MODE,
+            Attribute.AC_OPTIONAL_MODE,
+        )
+        return preset_mode if preset_mode == WINDFREE else None
+
+    @property
+    def preset_modes(self) -> list[str]:
+        """Return the currently available preset modes."""
+        return self._determine_preset_modes()
 
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set special modes (currently only windFree is supported)."""

--- a/custom_components/smartthings/climate.py
+++ b/custom_components/smartthings/climate.py
@@ -390,6 +390,7 @@ class SmartThingsAirConditioner(SmartThingsEntity, ClimateEntity):
             Capability.AIR_CONDITIONER_MODE,
             Attribute.AIR_CONDITIONER_MODE,
         )
+        # Samsung only supports WindFree while cooling-compatible modes are active.
         return current_mode not in {"auto", "heat"}
 
     async def async_set_fan_mode(self, fan_mode: str) -> None:
@@ -565,7 +566,7 @@ class SmartThingsAirConditioner(SmartThingsEntity, ClimateEntity):
             SWING_OFF,
         )
 
-    def _determine_preset_modes(self) -> list[str] | None:
+    def _determine_preset_modes(self) -> list[str]:
         """Return a list of available preset modes."""
         if self._windfree_available():
             return [WINDFREE]

--- a/custom_components/smartthings/manifest.json
+++ b/custom_components/smartthings/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.0.13",
+  "version": "2.0.14",
   "domain": "smartthings",
   "name": "SmartThings",
   "codeowners": ["@bakernigel"],

--- a/custom_components/smartthings/number.py
+++ b/custom_components/smartthings/number.py
@@ -32,52 +32,44 @@ from homeassistant.const import (
 
 _LOGGER = logging.getLogger(__name__)
 
+
 @dataclass(frozen=True, kw_only=True)
 class SmartThingsNumberDescription(NumberEntityDescription):
-    """Class describing SmartThings button entities."""
+    """Describe a SmartThings capability exposed as a NumberEntity."""
+
     key: Capability
     attribute: Attribute
     command: Command
     default_name: str
-    default_min_value: float
-    default_max_value: float
 
-# For future use ?
-CAPABILITIES_TO_NUMBER: dict[
-    Capability, dict[Attribute, list[SmartThingsNumberDescription]]
-] = {
-    Capability.THERMOSTAT_COOLING_SETPOINT: {
-        Attribute.COOLING_SETPOINT: [
-            SmartThingsNumberDescription(
-                key=Capability.THERMOSTAT_COOLING_SETPOINT,
-                attribute=Attribute.COOLING_SETPOINT,
-                translation_key="coolingSetpoint",
-                native_unit_of_measurement="F",
-                default_name="coolingSetpoint",
-                default_min_value=-22,
-                default_max_value=500,
-                step=1,
-                mode=NumberMode.AUTO,
-                command=Command.SET_COOLING_SETPOINT,                
-            )
-        ]
-     },
-    Capability.AUDIO_VOLUME: {
-        Attribute.VOLUME: [
-            SmartThingsNumberDescription(
-                key=Capability.AUDIO_VOLUME,
-                attribute=Attribute.VOLUME,
-                translation_key="audio_volume",
-                native_unit_of_measurement=PERCENTAGE,
-                default_name="Volume",
-                default_min_value=0,
-                default_max_value=100,
-                step=1,
-                mode=NumberMode.AUTO,
-                command=Command.SET_VOLUME,
-            )
-        ]
-     }
+# Keep this mapping intentionally small until more number capabilities are
+# proven useful. Right now it only covers the existing cooling setpoint entity
+# plus the added writable audio volume control.
+CAPABILITIES_TO_NUMBER: dict[Capability, SmartThingsNumberDescription] = {
+    Capability.THERMOSTAT_COOLING_SETPOINT: SmartThingsNumberDescription(
+        key=Capability.THERMOSTAT_COOLING_SETPOINT,
+        attribute=Attribute.COOLING_SETPOINT,
+        translation_key="thermostat_cooling_setpoint",
+        native_unit_of_measurement="F",
+        default_name="coolingSetpoint",
+        min_value=-22,
+        max_value=500,
+        step=1,
+        mode=NumberMode.AUTO,
+        command=Command.SET_COOLING_SETPOINT,
+    ),
+    Capability.AUDIO_VOLUME: SmartThingsNumberDescription(
+        key=Capability.AUDIO_VOLUME,
+        attribute=Attribute.VOLUME,
+        translation_key="audio_volume",
+        native_unit_of_measurement=PERCENTAGE,
+        default_name="Volume",
+        min_value=0,
+        max_value=100,
+        step=1,
+        mode=NumberMode.AUTO,
+        command=Command.SET_VOLUME,
+    ),
 }
 
 UNITS = {
@@ -94,32 +86,25 @@ async def async_setup_entry(
     entry: SmartThingsConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
-    """Add number entities for a config entry."""
-    _LOGGER.debug("NB Add number entities for a config entry")            
+    """Add supported SmartThings number entities for a config entry."""
+    _LOGGER.debug("NB Add number entities for a config entry")
     entry_data = entry.runtime_data
-    entities = []
-    for device in entry_data.devices.values():
-        for component, component_status in device.status.items():
-            for capability, attributes in CAPABILITIES_TO_NUMBER.items():
-                if capability not in component_status:
-                    continue
-                for attribute, descriptions in attributes.items():
-                    for description in descriptions:
-                        entities.append(
-                            SmartThingsNumberEntity(
-                                entry_data.client,
-                                device,
-                                component,
-                                capability,
-                                attribute,
-                                description,
-                            )
-                        )
-    async_add_entities(entities)
+    async_add_entities(
+        SmartThingsNumberEntity(
+            entry_data.client,
+            device,
+            component,
+            capability,
+        )
+        for device in entry_data.devices.values()
+        for component in device.status
+        for capability in CAPABILITIES_TO_NUMBER
+        if capability in device.status[component]
+    )
 
 
 class SmartThingsNumberEntity(SmartThingsEntity, NumberEntity):
-    """Define a SmartThings number."""
+    """Define a SmartThings number entity."""
 
     _attr_native_step = 1.0
     _attr_mode = NumberMode.AUTO
@@ -130,47 +115,47 @@ class SmartThingsNumberEntity(SmartThingsEntity, NumberEntity):
         device: FullDevice,
         component,
         capability: Capability,
-        attribute: Attribute,
-        description: SmartThingsNumberDescription,
     ) -> None:
-        """Initialize the instance."""
-        
+        """Initialize the number entity for a supported capability."""
+
         _LOGGER.debug(
         "NB SmartThingsNumberEntity(init) Device:%s component:%s capability:%s",
         device.device.label,
         component,
         capability,
-        ) 
-                         
+        )
+
         super().__init__(client, device, {capability}, component)
-        
+
+        description = CAPABILITIES_TO_NUMBER[capability]
         self.entity_description = description
-        self._attribute = attribute
+        self._attribute = description.attribute
         self.capability = capability
         self._attr_translation_key = description.translation_key
+        if capability == Capability.THERMOSTAT_COOLING_SETPOINT:
+            self._attr_name = f"{component} coolingSetpoint"
+        else:
+            if component == MAIN:
+                self._attr_name = description.default_name
+            else:
+                self._attr_name = f"{component} {description.default_name}"
         self._attr_mode = description.mode
         self._attr_unique_id = (
-            f"{device.device.device_id}_{component}_{capability}_{attribute}"
-        )
-        self._attr_name = (
-            description.default_name
-            if component == "main"
-            else f"{component} {description.default_name}"
+            f"{device.device.device_id}_{component}_{capability}_{self._attribute}"
         )
 
     @property
-    def options(self) -> dict:        
-        """Return the list of options."""
-        range_attribute = None
-        if self.capability == Capability.THERMOSTAT_COOLING_SETPOINT:
-            range_attribute = Attribute.COOLING_SETPOINT_RANGE
-
-        if range_attribute is None:
+    def options(self) -> dict | None:
+        """Return the supported range when the capability exposes one."""
+        if self.capability != Capability.THERMOSTAT_COOLING_SETPOINT:
             return None
 
-        ranges = self.get_attribute_value(self.capability, range_attribute)
-        _LOGGER.debug("NB Number options (range):%s", ranges,)         
-        return ranges       
+        ranges = self.get_attribute_value(
+            Capability.THERMOSTAT_COOLING_SETPOINT,
+            Attribute.COOLING_SETPOINT_RANGE,
+        )
+        _LOGGER.debug("NB Number options (range):%s", ranges,)
+        return ranges
 
     @property
     def native_value(self) -> float | None:
@@ -182,22 +167,22 @@ class SmartThingsNumberEntity(SmartThingsEntity, NumberEntity):
             return int(value)
         return float(value)
 
-    @property        
+    @property
     def native_min_value(self):
         """Return the minimum value."""
         range = self.options
-        if range is not None and isinstance(range, dict) and 'minimum' in range:
-            return int(range['minimum'])
-        return self.entity_description.default_min_value
+        if range is not None and isinstance(range, dict) and "minimum" in range:
+            return int(range["minimum"])
+        return self.entity_description.min_value
 
     @property
     def native_max_value(self) -> float:
         """Return the maximum value."""
-        range = self.options        
-        if range is not None and isinstance(range, dict) and 'maximum' in range:
-            return int(range['maximum'])
-        return self.entity_description.default_max_value
-        
+        range = self.options
+        if range is not None and isinstance(range, dict) and "maximum" in range:
+            return int(range["maximum"])
+        return self.entity_description.max_value
+
     @property
     def native_unit_of_measurement(self) -> str | None:
         """Return the unit this state is expressed in."""
@@ -206,14 +191,12 @@ class SmartThingsNumberEntity(SmartThingsEntity, NumberEntity):
             UNITS.get(unit, unit)
             if unit
             else self.entity_description.native_unit_of_measurement
-        )                         
-
+        )
 
     async def async_set_native_value(self, value: float) -> None:
         """Set the value."""
-        argument = int(value) if self.capability == Capability.AUDIO_VOLUME else int(value)
         await self.execute_device_command(
             self.capability,
             self.entity_description.command,
-            argument,
+            int(value),
         )

--- a/custom_components/smartthings/number.py
+++ b/custom_components/smartthings/number.py
@@ -36,7 +36,11 @@ _LOGGER = logging.getLogger(__name__)
 class SmartThingsNumberDescription(NumberEntityDescription):
     """Class describing SmartThings button entities."""
     key: Capability
+    attribute: Attribute
     command: Command
+    default_name: str
+    default_min_value: float
+    default_max_value: float
 
 # For future use ?
 CAPABILITIES_TO_NUMBER: dict[
@@ -46,16 +50,34 @@ CAPABILITIES_TO_NUMBER: dict[
         Attribute.COOLING_SETPOINT: [
             SmartThingsNumberDescription(
                 key=Capability.THERMOSTAT_COOLING_SETPOINT,
+                attribute=Attribute.COOLING_SETPOINT,
                 translation_key="coolingSetpoint",
                 native_unit_of_measurement="F",
-                min_value=-22,
-                max_value=500,
+                default_name="coolingSetpoint",
+                default_min_value=-22,
+                default_max_value=500,
                 step=1,
                 mode=NumberMode.AUTO,
                 command=Command.SET_COOLING_SETPOINT,                
             )
         ]
-     }       
+     },
+    Capability.AUDIO_VOLUME: {
+        Attribute.VOLUME: [
+            SmartThingsNumberDescription(
+                key=Capability.AUDIO_VOLUME,
+                attribute=Attribute.VOLUME,
+                translation_key="audio_volume",
+                native_unit_of_measurement=PERCENTAGE,
+                default_name="Volume",
+                default_min_value=0,
+                default_max_value=100,
+                step=1,
+                mode=NumberMode.AUTO,
+                command=Command.SET_VOLUME,
+            )
+        ]
+     }
 }
 
 UNITS = {
@@ -75,55 +97,90 @@ async def async_setup_entry(
     """Add number entities for a config entry."""
     _LOGGER.debug("NB Add number entities for a config entry")            
     entry_data = entry.runtime_data
-    async_add_entities(
-        SmartThingsNumberEntity(entry_data.client, device, component)
-        for device in entry_data.devices.values()
-        for component in device.status
-        if Capability.THERMOSTAT_COOLING_SETPOINT in device.status[component]
-    )
+    entities = []
+    for device in entry_data.devices.values():
+        for component, component_status in device.status.items():
+            for capability, attributes in CAPABILITIES_TO_NUMBER.items():
+                if capability not in component_status:
+                    continue
+                for attribute, descriptions in attributes.items():
+                    for description in descriptions:
+                        entities.append(
+                            SmartThingsNumberEntity(
+                                entry_data.client,
+                                device,
+                                component,
+                                capability,
+                                attribute,
+                                description,
+                            )
+                        )
+    async_add_entities(entities)
 
 
 class SmartThingsNumberEntity(SmartThingsEntity, NumberEntity):
     """Define a SmartThings number."""
 
-    _attr_translation_key = "thermostat_cooling_setpoint"
     _attr_native_step = 1.0
     _attr_mode = NumberMode.AUTO
 
-    def __init__(self, client: SmartThings, device: FullDevice, component) -> None:
+    def __init__(
+        self,
+        client: SmartThings,
+        device: FullDevice,
+        component,
+        capability: Capability,
+        attribute: Attribute,
+        description: SmartThingsNumberDescription,
+    ) -> None:
         """Initialize the instance."""
         
         _LOGGER.debug(
         "NB SmartThingsNumberEntity(init) Device:%s component:%s capability:%s",
         device.device.label,
         component,
-        Capability.THERMOSTAT_COOLING_SETPOINT,                       
+        capability,
         ) 
                          
-        super().__init__(client, device, {Capability.THERMOSTAT_COOLING_SETPOINT}, component)
+        super().__init__(client, device, {capability}, component)
         
-        self._attr_unique_id = f"{device.device.device_id}_{component}_{Capability.THERMOSTAT_COOLING_SETPOINT}_{Attribute.COOLING_SETPOINT}"
-        self._attr_name = f"{component} coolingSetpoint"
-        self.capability = Capability.THERMOSTAT_COOLING_SETPOINT
+        self.entity_description = description
+        self._attribute = attribute
+        self.capability = capability
+        self._attr_translation_key = description.translation_key
+        self._attr_mode = description.mode
+        self._attr_unique_id = (
+            f"{device.device.device_id}_{component}_{capability}_{attribute}"
+        )
+        self._attr_name = (
+            description.default_name
+            if component == "main"
+            else f"{component} {description.default_name}"
+        )
 
     @property
     def options(self) -> dict:        
         """Return the list of options."""
-        ranges = self.get_attribute_value(
-            Capability.THERMOSTAT_COOLING_SETPOINT,
-            Attribute.COOLING_SETPOINT_RANGE,
-        )
+        range_attribute = None
+        if self.capability == Capability.THERMOSTAT_COOLING_SETPOINT:
+            range_attribute = Attribute.COOLING_SETPOINT_RANGE
+
+        if range_attribute is None:
+            return None
+
+        ranges = self.get_attribute_value(self.capability, range_attribute)
         _LOGGER.debug("NB Number options (range):%s", ranges,)         
         return ranges       
 
     @property
     def native_value(self) -> float | None:
         """Return the current value."""
-        return int(
-            self.get_attribute_value(
-                Capability.THERMOSTAT_COOLING_SETPOINT, Attribute.COOLING_SETPOINT
-            )
-        )
+        value = self.get_attribute_value(self.capability, self._attribute)
+        if value is None:
+            return None
+        if self.capability == Capability.AUDIO_VOLUME:
+            return int(value)
+        return float(value)
 
     @property        
     def native_min_value(self):
@@ -131,7 +188,7 @@ class SmartThingsNumberEntity(SmartThingsEntity, NumberEntity):
         range = self.options
         if range is not None and isinstance(range, dict) and 'minimum' in range:
             return int(range['minimum'])
-        return 0  # Or another default value, depending on your requirements                 
+        return self.entity_description.default_min_value
 
     @property
     def native_max_value(self) -> float:
@@ -139,12 +196,12 @@ class SmartThingsNumberEntity(SmartThingsEntity, NumberEntity):
         range = self.options        
         if range is not None and isinstance(range, dict) and 'maximum' in range:
             return int(range['maximum'])
-        return 100                    
+        return self.entity_description.default_max_value
         
     @property
     def native_unit_of_measurement(self) -> str | None:
         """Return the unit this state is expressed in."""
-        unit = self._internal_state[self.capability][Attribute.COOLING_SETPOINT].unit
+        unit = self._internal_state[self.capability][self._attribute].unit
         return (
             UNITS.get(unit, unit)
             if unit
@@ -154,8 +211,9 @@ class SmartThingsNumberEntity(SmartThingsEntity, NumberEntity):
 
     async def async_set_native_value(self, value: float) -> None:
         """Set the value."""
+        argument = int(value) if self.capability == Capability.AUDIO_VOLUME else int(value)
         await self.execute_device_command(
-            Capability.THERMOSTAT_COOLING_SETPOINT,
-            Command.SET_COOLING_SETPOINT,
-            int(value),
+            self.capability,
+            self.entity_description.command,
+            argument,
         )

--- a/custom_components/smartthings/sensor.py
+++ b/custom_components/smartthings/sensor.py
@@ -180,6 +180,17 @@ CAPABILITY_TO_SENSORS: dict[
             )
         ]
     },
+    Capability.AUDIO_VOLUME: {
+        Attribute.VOLUME: [
+            # Keep the read-only volume sensor for compatibility with existing setups.
+            SmartThingsSensorEntityDescription(
+                key=Attribute.VOLUME,
+                translation_key="audio_volume",
+                name="Volume",  # From first doc
+                native_unit_of_measurement=PERCENTAGE,
+            )
+        ]
+    },
     Capability.BATTERY: {
         Attribute.BATTERY: [
             SmartThingsSensorEntityDescription(

--- a/custom_components/smartthings/sensor.py
+++ b/custom_components/smartthings/sensor.py
@@ -180,16 +180,6 @@ CAPABILITY_TO_SENSORS: dict[
             )
         ]
     },
-    Capability.AUDIO_VOLUME: {
-        Attribute.VOLUME: [
-            SmartThingsSensorEntityDescription(
-                key=Attribute.VOLUME,
-                translation_key="audio_volume",
-                name="Volume",  # From first doc
-                native_unit_of_measurement=PERCENTAGE,
-            )
-        ]
-    },
     Capability.BATTERY: {
         Attribute.BATTERY: [
             SmartThingsSensorEntityDescription(

--- a/custom_components/smartthings/switch.py
+++ b/custom_components/smartthings/switch.py
@@ -152,6 +152,26 @@ def _supports_ocf_display_switch(device: FullDevice) -> bool:
         main_status, Capability.EXECUTE
     )
 
+
+def _is_display_visible(options: list[str] | str) -> bool | None:
+    """Return the visible display state for Samsung OCF payload values.
+
+    This model reports the display control with inverted semantics:
+    - ``Light_On`` means the panel light/display is turned off/hidden
+    - ``Light_Off`` means the panel light/display is turned on/visible
+
+    Keep this inversion explicit here so the behavior is obvious to future
+    maintainers instead of being buried in optimistic update logic.
+    """
+    if isinstance(options, str):
+        options = [options]
+
+    if any(option in options for option in OCF_DISPLAY_ON_VALUE):
+        return False
+    if any(option in options for option in OCF_DISPLAY_OFF_VALUE):
+        return True
+    return None
+
 #AC_CAPABILITIES = (
 #    Capability.AIR_CONDITIONER_MODE,
 #    Capability.AIR_CONDITIONER_FAN_MODE,
@@ -334,19 +354,17 @@ class SamsungOcfDisplaySwitch(SmartThingsEntity, SwitchEntity):
             return
 
         options = payload.get(OCF_DISPLAY_KEY)
-        if isinstance(options, list):
-            if any(option in options for option in OCF_DISPLAY_ON_VALUE):
-                self._is_on = True
-            elif any(option in options for option in OCF_DISPLAY_OFF_VALUE):
-                self._is_on = False
-        elif isinstance(options, str):
-            if any(option == options for option in OCF_DISPLAY_ON_VALUE):
-                self._is_on = True
-            elif any(option == options for option in OCF_DISPLAY_OFF_VALUE):
-                self._is_on = False
+        display_visible = _is_display_visible(options)
+        if display_visible is not None:
+            self._is_on = display_visible
 
     def _set_execute_state(self, options: list[str], is_on: bool) -> None:
-        """Optimistically update local execute state."""
+        """Optimistically update local execute state.
+
+        ``is_on`` represents the Home Assistant switch state, meaning the AC
+        display is visible. This intentionally does not match the Samsung OCF
+        command names for this model, which are inverted.
+        """
         status = self._internal_state.get(Capability.EXECUTE, {}).get(Attribute.DATA)
         if status is not None:
             status.value = {"payload": {OCF_DISPLAY_KEY: options}}
@@ -363,23 +381,31 @@ class SamsungOcfDisplaySwitch(SmartThingsEntity, SwitchEntity):
         )
 
     async def async_turn_off(self, **kwargs: Any) -> None:
-        """Turn the display off."""
-        await self.execute_device_command(
-            Capability.EXECUTE,
-            Command.EXECUTE,
-            argument=[OCF_DISPLAY_PAGE, {OCF_DISPLAY_KEY: OCF_DISPLAY_OFF_VALUE}],
-        )
-        self._set_execute_state(OCF_DISPLAY_OFF_VALUE, False)
-        self.async_write_ha_state()
+        """Turn the display off.
 
-    async def async_turn_on(self, **kwargs: Any) -> None:
-        """Turn the display on."""
+        Samsung's OCF payload is inverted on this model:
+        sending ``Light_On`` hides the panel display.
+        """
         await self.execute_device_command(
             Capability.EXECUTE,
             Command.EXECUTE,
             argument=[OCF_DISPLAY_PAGE, {OCF_DISPLAY_KEY: OCF_DISPLAY_ON_VALUE}],
         )
-        self._set_execute_state(OCF_DISPLAY_ON_VALUE, True)
+        self._set_execute_state(OCF_DISPLAY_ON_VALUE, False)
+        self.async_write_ha_state()
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn the display on.
+
+        Samsung's OCF payload is inverted on this model:
+        sending ``Light_Off`` makes the panel display visible.
+        """
+        await self.execute_device_command(
+            Capability.EXECUTE,
+            Command.EXECUTE,
+            argument=[OCF_DISPLAY_PAGE, {OCF_DISPLAY_KEY: OCF_DISPLAY_OFF_VALUE}],
+        )
+        self._set_execute_state(OCF_DISPLAY_OFF_VALUE, True)
         self.async_write_ha_state()
 
     @property

--- a/custom_components/smartthings/switch.py
+++ b/custom_components/smartthings/switch.py
@@ -28,12 +28,7 @@ from .entity import SmartThingsEntity
 
 _LOGGER = logging.getLogger(__name__)
 
-OCF_DISPLAY_SUPPORTED_MODELS = {"ARTIK051_PRAC_20K"}
-OCF_DISPLAY_PAGE = "/mode/vs/0"
-OCF_DISPLAY_KEY = "x.com.samsung.da.options"
-OCF_DISPLAY_ON_VALUE = ["Light_On"]
-OCF_DISPLAY_OFF_VALUE = ["Light_Off"]
-
+# Generic native-capability switch support.
 AIR_CONDITIONER_DISPLAY = getattr(
     Capability,
     "SAMSUNG_CE_AIR_CONDITIONER_DISPLAY",
@@ -120,57 +115,6 @@ def _has_capability(component_status, capability) -> bool:
         return True
     capability_name = str(capability)
     return any(str(status_capability) == capability_name for status_capability in component_status)
-
-
-def _device_model(device: FullDevice) -> str | None:
-    """Return the Samsung model identifier when available."""
-    if device.device.ocf and device.device.ocf.model_number:
-        return device.device.ocf.model_number.split("|")[0]
-
-    ocf_status = device.status.get(MAIN, {}).get(Capability.OCF)
-    if ocf_status is None:
-        return None
-
-    model_status = ocf_status.get(Attribute.MNMO)
-    if model_status is None or model_status.value is None:
-        return None
-    return str(model_status.value).split("|")[0]
-
-
-def _supports_ocf_display_switch(device: FullDevice) -> bool:
-    """Return whether the device should use the Samsung OCF display switch path."""
-    main_status = device.status.get(MAIN)
-    if main_status is None:
-        return False
-
-    if _has_capability(main_status, AIR_CONDITIONER_DISPLAY) or _has_capability(
-        main_status, AIR_CONDITIONER_LIGHTING
-    ):
-        return False
-
-    return _device_model(device) in OCF_DISPLAY_SUPPORTED_MODELS and _has_capability(
-        main_status, Capability.EXECUTE
-    )
-
-
-def _is_display_visible(options: list[str] | str) -> bool | None:
-    """Return the visible display state for Samsung OCF payload values.
-
-    This model reports the display control with inverted semantics:
-    - ``Light_On`` means the panel light/display is turned off/hidden
-    - ``Light_Off`` means the panel light/display is turned on/visible
-
-    Keep this inversion explicit here so the behavior is obvious to future
-    maintainers instead of being buried in optimistic update logic.
-    """
-    if isinstance(options, str):
-        options = [options]
-
-    if any(option in options for option in OCF_DISPLAY_ON_VALUE):
-        return False
-    if any(option in options for option in OCF_DISPLAY_OFF_VALUE):
-        return True
-    return None
 
 #AC_CAPABILITIES = (
 #    Capability.AIR_CONDITIONER_MODE,
@@ -310,8 +254,73 @@ class SmartThingsSwitch(SmartThingsEntity, SwitchEntity):
         return (self.get_attribute_value(self._capability, attribute_to_use) == CAPABILITIES[self._capability]["is_on_key"])
 
 
+# Samsung OCF display support for specific AC models.
+OCF_DISPLAY_SUPPORTED_MODELS = {"ARTIK051_PRAC_20K"}
+OCF_DISPLAY_PAGE = "/mode/vs/0"
+OCF_DISPLAY_KEY = "x.com.samsung.da.options"
+OCF_DISPLAY_ON_VALUE = ["Light_On"]
+OCF_DISPLAY_OFF_VALUE = ["Light_Off"]
+
+
+def _device_model(device: FullDevice) -> str | None:
+    """Return the Samsung model identifier when available."""
+    if device.device.ocf and device.device.ocf.model_number:
+        return device.device.ocf.model_number.split("|")[0]
+
+    ocf_status = device.status.get(MAIN, {}).get(Capability.OCF)
+    if ocf_status is None:
+        return None
+
+    model_status = ocf_status.get(Attribute.MNMO)
+    if model_status is None or model_status.value is None:
+        return None
+    return str(model_status.value).split("|")[0]
+
+
+def _supports_ocf_display_switch(device: FullDevice) -> bool:
+    """Return whether the device should use the Samsung OCF display switch path."""
+    main_status = device.status.get(MAIN)
+    if main_status is None:
+        return False
+
+    if _has_capability(main_status, AIR_CONDITIONER_DISPLAY) or _has_capability(
+        main_status, AIR_CONDITIONER_LIGHTING
+    ):
+        return False
+
+    return _device_model(device) in OCF_DISPLAY_SUPPORTED_MODELS and _has_capability(
+        main_status, Capability.EXECUTE
+    )
+
+
+def _is_display_visible(options: list[str] | str) -> bool | None:
+    """Return the visible display state for Samsung OCF payload values.
+
+    This model reports the display control with inverted semantics:
+    - ``Light_On`` means the panel light/display is turned off/hidden
+    - ``Light_Off`` means the panel light/display is turned on/visible
+
+    Keep this inversion explicit here so the behavior is obvious to future
+    maintainers instead of being buried in optimistic update logic.
+    """
+    if isinstance(options, str):
+        options = [options]
+
+    if any(option in options for option in OCF_DISPLAY_ON_VALUE):
+        return False
+    if any(option in options for option in OCF_DISPLAY_OFF_VALUE):
+        return True
+    return None
+
+
 class SamsungOcfDisplaySwitch(SmartThingsEntity, SwitchEntity):
-    """Model-scoped Samsung OCF display switch."""
+    """Samsung OCF display switch for models without a native display capability.
+
+    ARTIK051_PRAC_20K does not expose a native SmartThings display/light
+    capability in diagnostics, but it does support the Samsung OCF execute
+    page at ``/mode/vs/0``. Keep this logic narrow and separate from the
+    generic switch handling.
+    """
 
     _attr_has_entity_name = True
     _attr_name = "Display"

--- a/custom_components/smartthings/switch.py
+++ b/custom_components/smartthings/switch.py
@@ -28,6 +28,19 @@ from .entity import SmartThingsEntity
 
 _LOGGER = logging.getLogger(__name__)
 
+AIR_CONDITIONER_DISPLAY = getattr(
+    Capability,
+    "SAMSUNG_CE_AIR_CONDITIONER_DISPLAY",
+    "samsungce.airConditionerDisplay",
+)
+AIR_CONDITIONER_LIGHTING = getattr(
+    Capability,
+    "SAMSUNG_CE_AIR_CONDITIONER_LIGHTING",
+    "samsungce.airConditionerLighting",
+)
+DISPLAY_ATTRIBUTE = getattr(Attribute, "DISPLAY", "display")
+LIGHTING_ATTRIBUTE = getattr(Attribute, "LIGHTING", "lighting")
+
 CAPABILITIES = {
     Capability.SWITCH: {
         "attribute" : Attribute.SWITCH,
@@ -77,8 +90,30 @@ CAPABILITIES = {
         "is_on_key" : "True",
         "off_command" : Command.DEACTIVATE,
         "on_command" : Command.ACTIVATE
-    }        
+    },
+    AIR_CONDITIONER_DISPLAY: {
+        "attribute": DISPLAY_ATTRIBUTE,
+        "name": "Display",
+        "is_on_key": "on",
+        "off_command": Command.OFF,
+        "on_command": Command.ON,
+    },
+    AIR_CONDITIONER_LIGHTING: {
+        "attribute": LIGHTING_ATTRIBUTE,
+        "name": "Display",
+        "is_on_key": "on",
+        "off_command": Command.OFF,
+        "on_command": Command.ON,
+    },
 }    
+
+
+def _has_capability(component_status, capability) -> bool:
+    """Return whether a component exposes a capability."""
+    if capability in component_status:
+        return True
+    capability_name = str(capability)
+    return any(str(status_capability) == capability_name for status_capability in component_status)
 
 #AC_CAPABILITIES = (
 #    Capability.AIR_CONDITIONER_MODE,
@@ -107,7 +142,11 @@ async def async_setup_entry(
             )                          
                
             for capability in CAPABILITIES:
-                if capability not in device.status[component]:
+                if capability == AIR_CONDITIONER_DISPLAY and _has_capability(
+                    device.status[component], AIR_CONDITIONER_LIGHTING
+                ):
+                    continue
+                if not _has_capability(device.status[component], capability):
                     _LOGGER.debug(
                         "NB Capability not on device - continuing to next capability Device:%s Component:%s Capability:%s",
                         device.device.label,
@@ -163,6 +202,13 @@ class SmartThingsSwitch(SmartThingsEntity, SwitchEntity):
     @property
     def unique_id(self) -> str:
         """Return a unique ID."""
+
+        if self._capability in (AIR_CONDITIONER_DISPLAY, AIR_CONDITIONER_LIGHTING):
+            attribute = CAPABILITIES[self._capability]["attribute"]
+            return (
+                f"{self.device.device.device_id}.{self._component}."
+                f"{self._capability}.{attribute}"
+            )
         
         switch_name = ""
         

--- a/custom_components/smartthings/switch.py
+++ b/custom_components/smartthings/switch.py
@@ -22,11 +22,17 @@ from homeassistant.components.switch import SwitchEntity
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from . import SmartThingsConfigEntry
+from . import FullDevice, SmartThingsConfigEntry
 from .const import MAIN
 from .entity import SmartThingsEntity
 
 _LOGGER = logging.getLogger(__name__)
+
+OCF_DISPLAY_SUPPORTED_MODELS = {"ARTIK051_PRAC_20K"}
+OCF_DISPLAY_PAGE = "/mode/vs/0"
+OCF_DISPLAY_KEY = "x.com.samsung.da.options"
+OCF_DISPLAY_ON_VALUE = ["Light_On"]
+OCF_DISPLAY_OFF_VALUE = ["Light_Off"]
 
 AIR_CONDITIONER_DISPLAY = getattr(
     Capability,
@@ -115,6 +121,37 @@ def _has_capability(component_status, capability) -> bool:
     capability_name = str(capability)
     return any(str(status_capability) == capability_name for status_capability in component_status)
 
+
+def _device_model(device: FullDevice) -> str | None:
+    """Return the Samsung model identifier when available."""
+    if device.device.ocf and device.device.ocf.model_number:
+        return device.device.ocf.model_number.split("|")[0]
+
+    ocf_status = device.status.get(MAIN, {}).get(Capability.OCF)
+    if ocf_status is None:
+        return None
+
+    model_status = ocf_status.get(Attribute.MNMO)
+    if model_status is None or model_status.value is None:
+        return None
+    return str(model_status.value).split("|")[0]
+
+
+def _supports_ocf_display_switch(device: FullDevice) -> bool:
+    """Return whether the device should use the Samsung OCF display switch path."""
+    main_status = device.status.get(MAIN)
+    if main_status is None:
+        return False
+
+    if _has_capability(main_status, AIR_CONDITIONER_DISPLAY) or _has_capability(
+        main_status, AIR_CONDITIONER_LIGHTING
+    ):
+        return False
+
+    return _device_model(device) in OCF_DISPLAY_SUPPORTED_MODELS and _has_capability(
+        main_status, Capability.EXECUTE
+    )
+
 #AC_CAPABILITIES = (
 #    Capability.AIR_CONDITIONER_MODE,
 #    Capability.AIR_CONDITIONER_FAN_MODE,
@@ -132,6 +169,14 @@ async def async_setup_entry(
     entry_data = entry.runtime_data
     entities = []
     for device in entry_data.devices.values():
+        if _supports_ocf_display_switch(device):
+            entities.append(
+                SamsungOcfDisplaySwitch(
+                    entry_data.client,
+                    device,
+                    MAIN,
+                )
+            )
     
         for component in device.status: 
             _LOGGER.debug(
@@ -243,6 +288,104 @@ class SmartThingsSwitch(SmartThingsEntity, SwitchEntity):
         """Return true if switch is on."""
         attribute_to_use = CAPABILITIES[self._capability]["attribute"]
         return (self.get_attribute_value(self._capability, attribute_to_use) == CAPABILITIES[self._capability]["is_on_key"])
+
+
+class SamsungOcfDisplaySwitch(SmartThingsEntity, SwitchEntity):
+    """Model-scoped Samsung OCF display switch."""
+
+    _attr_has_entity_name = True
+    _attr_name = "Display"
+    _attr_assumed_state = True
+
+    def __init__(
+        self,
+        client,
+        device: FullDevice,
+        component: str,
+    ) -> None:
+        """Initialize the OCF display switch."""
+        super().__init__(client, device, {Capability.EXECUTE}, component)
+        self._is_on: bool | None = None
+
+    @property
+    def unique_id(self) -> str:
+        """Return a unique ID."""
+        return f"{self.device.device.device_id}.{self.component}.ocf_display"
+
+    def _update_attr(self) -> None:
+        """Update cached switch state from execute payload data."""
+        status = self._internal_state.get(Capability.EXECUTE, {}).get(Attribute.DATA)
+        if status is None:
+            return
+
+        href = None
+        payload = None
+        if isinstance(status.data, dict):
+            href = status.data.get("href")
+            if isinstance(status.data.get("payload"), dict):
+                payload = status.data["payload"]
+
+        if payload is None and isinstance(status.value, dict):
+            if isinstance(status.value.get("payload"), dict):
+                payload = status.value["payload"]
+            href = href or status.value.get("href")
+
+        if href not in (None, OCF_DISPLAY_PAGE) or not isinstance(payload, dict):
+            return
+
+        options = payload.get(OCF_DISPLAY_KEY)
+        if isinstance(options, list):
+            if any(option in options for option in OCF_DISPLAY_ON_VALUE):
+                self._is_on = True
+            elif any(option in options for option in OCF_DISPLAY_OFF_VALUE):
+                self._is_on = False
+        elif isinstance(options, str):
+            if any(option == options for option in OCF_DISPLAY_ON_VALUE):
+                self._is_on = True
+            elif any(option == options for option in OCF_DISPLAY_OFF_VALUE):
+                self._is_on = False
+
+    def _set_execute_state(self, options: list[str], is_on: bool) -> None:
+        """Optimistically update local execute state."""
+        status = self._internal_state.get(Capability.EXECUTE, {}).get(Attribute.DATA)
+        if status is not None:
+            status.value = {"payload": {OCF_DISPLAY_KEY: options}}
+            status.data = {"href": OCF_DISPLAY_PAGE}
+        self._is_on = is_on
+
+    async def async_added_to_hass(self) -> None:
+        """Subscribe to updates and request initial execute state."""
+        await super().async_added_to_hass()
+        await self.execute_device_command(
+            Capability.EXECUTE,
+            Command.EXECUTE,
+            argument=[OCF_DISPLAY_PAGE],
+        )
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn the display off."""
+        await self.execute_device_command(
+            Capability.EXECUTE,
+            Command.EXECUTE,
+            argument=[OCF_DISPLAY_PAGE, {OCF_DISPLAY_KEY: OCF_DISPLAY_OFF_VALUE}],
+        )
+        self._set_execute_state(OCF_DISPLAY_OFF_VALUE, False)
+        self.async_write_ha_state()
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn the display on."""
+        await self.execute_device_command(
+            Capability.EXECUTE,
+            Command.EXECUTE,
+            argument=[OCF_DISPLAY_PAGE, {OCF_DISPLAY_KEY: OCF_DISPLAY_ON_VALUE}],
+        )
+        self._set_execute_state(OCF_DISPLAY_ON_VALUE, True)
+        self.async_write_ha_state()
+
+    @property
+    def is_on(self) -> bool:
+        """Return true if the display is on."""
+        return bool(self._is_on)
   
 #samsungce.powerCool
 #activated


### PR DESCRIPTION
# Discosure

- I have use AI to create these changes.
- Each file has been manually reviewed and restructured manually before creating this PR.
- I do thing there could be better structure around the implementation of the OCF parts if we find more devices that needs it but i didn't want to create a 2000 line change PR that is impossible to review.
- It has been manually tested.
- Please comment if you think things are wrong / want me to change and i'll do the work!


## Summary

This PR improves Samsung air conditioner support in the custom SmartThings integration by:

- making `windFree` availability dynamic so it is only offered when the AC is in a cooling-compatible mode
- adding a writable `NumberEntity` for `audioVolume`
- keeping the existing read-only `audioVolume` sensor for compatibility with existing setups
- adding a narrow Samsung OCF `Display` switch for model `ARTIK051_PRAC_20K`

The goal is to keep the current `smartthings2` architecture and add only the missing functionality that is already proven useful on real hardware.

## Background

This work came out of comparing three local integrations:

- `smartthings`: https://github.com/bakernigel/smartthings
- `smartthings-custom`: https://github.com/veista/smartthings
- `smartthings2`: https://github.com/bakernigel/smartthings2

The changes in this PR were implemented in the fork here:

- `smartthings2-fork`: https://github.com/Logonz/smartthings2

`smartthings2` is the cleaner long-term base, but it did not fully preserve some Samsung AC behavior that existed in older forks.

For the tested AC, Home Assistant diagnostics showed:

- model: `ARTIK051_PRAC_20K`
- `custom.airConditionerOptionalMode` includes `windFree`
- `audioVolume` is present
- `execute` is present
- native `samsungce.airConditionerDisplay` / `samsungce.airConditionerLighting` are not present

That means:

- WindFree can be handled through the native optional-mode capability
- volume can be handled through the native `audioVolume` capability
- display control cannot use a native display capability on this model and must use the Samsung OCF `execute` path instead

## Changes

### 1. WindFree preset availability

`windFree` is still the only optional AC mode exposed as a Home Assistant preset, but it is now only offered when the current AC mode is not `auto` or `heat`.

This keeps the current `smartthings2` preset model simple while matching actual device behavior more closely.

### 2. Writable volume number

A new writable `NumberEntity` is added for `Capability.AUDIO_VOLUME`:

- range: `0-100`
- unit: `%`
- command: `setVolume`

This allows direct control of volume from Home Assistant while keeping the implementation close to the existing number entity structure.

### 3. Compatibility with the existing volume sensor

The original read-only `audioVolume` sensor is intentionally kept.

Although the writable number is a better control surface, keeping the sensor avoids an entity-type migration for existing users and reduces upstream compatibility risk.

### 4. Samsung OCF display switch for `ARTIK051_PRAC_20K`

Some Samsung AC models do not expose native `airConditionerDisplay` or `airConditionerLighting` capabilities through SmartThings, but they do expose `execute`.

For `ARTIK051_PRAC_20K`, this PR adds a narrow `Display` switch that uses:

- page: `"/mode/vs/0"`
- key: `"x.com.samsung.da.options"`
- on payload: `["Light_Off"]`
- off payload: `["Light_On"]`

The command names are intentionally inverted relative to the Home Assistant switch state on this model:

- `Light_On` hides the panel display
- `Light_Off` makes the panel display visible

This behavior was verified on real hardware and is documented in code because it is not intuitive.

## Why This Scope

This PR intentionally keeps the scope narrow and only includes behavior that was needed and verified on real hardware.

It does not try to port the full Samsung AC behavior from older custom forks. The aim is to keep the change targeted, understandable, and upstreamable.

## Implementation Notes

- the Samsung OCF display switch is intentionally model-scoped to `ARTIK051_PRAC_20K`
- native display/light capability support is still preserved where SmartThings actually exposes it
- the number entity structure was kept close to the original implementation rather than introducing a broad new abstraction
- the sensor is retained for compatibility, while the number entity provides control

## Testing

Tested locally in Home Assistant with a real Samsung AC:

- `Volume` appears as a writable number and updates correctly
- `Display` appears as a switch and toggles the front display correctly
- the inverted OCF semantics were verified on-device
- `windFree` is no longer offered in `auto` or `heat`

Basic syntax validation also passed with `python3 -m py_compile` for the modified files.

## Compatibility / Risk

Known compatibility considerations:

- `audioVolume` now appears as both a sensor and a number by design
- the OCF display switch is intentionally narrow and only created for a known model
- the OCF state parsing depends on Samsung's vendor `execute` payload shape for this model

This was chosen as the safest balance between adding missing functionality and avoiding regressions for existing users.

## Follow-up Ideas

Possible future work, if desired:

- add tests for the model-scoped OCF display switch
- add tests for dynamic WindFree availability
- evaluate whether additional Samsung OCF models share the same display payload
- revisit volume-entity migration only with a deliberate deprecation plan
